### PR TITLE
Fix mobile horizontal overflow issues on landing sections

### DIFF
--- a/components/general/contacto.js
+++ b/components/general/contacto.js
@@ -122,7 +122,7 @@ export default function ContactoComponent() {
       `}</style>
 
       <section
-        className="py-16 lg:py-24 relative bg-gradient-to-br from-blue-800 to-blue-950"
+        className="relative overflow-hidden py-16 lg:py-24 bg-gradient-to-br from-blue-800 to-blue-950"
         id="contacto"
       >
         {/* Background elements */}
@@ -283,7 +283,7 @@ export default function ContactoComponent() {
                         <h4 className="font-semibold text-slate-800 mb-1">
                           {info.title}
                         </h4>
-                        <p className="text-gray-600 whitespace-pre-line">
+                        <p className="text-gray-600 whitespace-pre-line break-words">
                           {info.content}
                         </p>
                       </div>

--- a/components/general/equipamiento.js
+++ b/components/general/equipamiento.js
@@ -57,7 +57,7 @@ export default function EquipamientoComponent() {
         .delay-2000 { animation-delay: 2000ms; }
       `}</style>
 
-      <section className="py-16 lg:py-24 relative bg-gradient-to-br from-blue-800 to-blue-950 text-white" id="equipamiento">
+      <section className="relative overflow-hidden py-16 lg:py-24 bg-gradient-to-br from-blue-800 to-blue-950 text-white" id="equipamiento">
         {/* Background elements */}
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-32 left-20 w-72 h-72 bg-blue-500/5 rounded-full blur-3xl animate-pulse"></div>

--- a/components/general/hero.js
+++ b/components/general/hero.js
@@ -41,16 +41,16 @@ export default function HeroComponent() {
         .delay-3000 { animation-delay: 3000ms; }
       `}</style>
 
-      {/* Animated background elements */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-cyan-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-blue-400/5 rounded-full blur-3xl animate-pulse delay-500"></div>
-      </div>
-
       {/* Hero Section */}
-      <div className="relative pt-20 lg:pt-24 pb-16 lg:pb-24 bg-gradient-to-br from-blue-950 to-blue-800 text-white ">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="relative overflow-hidden pt-20 lg:pt-24 pb-16 lg:pb-24 bg-gradient-to-br from-blue-950 to-blue-800 text-white">
+        {/* Animated background elements */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-500/10 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-cyan-500/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-blue-400/5 rounded-full blur-3xl animate-pulse delay-500"></div>
+        </div>
+
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             {/* Main Heading */}
             <h1 className="text-4xl sm:text-5xl lg:text-7xl font-bold text-white mb-6 lg:mb-8 animate-fade-in-up">
@@ -109,11 +109,11 @@ export default function HeroComponent() {
         </div>
 
         {/* Floating elements */}
-        <div className="absolute top-1/4 left-10 w-2 h-2 bg-cyan-400 rounded-full animate-ping delay-1000"></div>
-        <div className="absolute top-1/3 right-20 w-3 h-3 bg-blue-500 rounded-full animate-ping delay-2000"></div>
-        <div className="absolute bottom-1/4 left-1/4 w-1 h-1 bg-blue-400 rounded-full animate-ping delay-3000"></div>
-        <div className="absolute top-1/2 right-1/3 w-2 h-2 bg-cyan-300 rounded-full animate-ping delay-1000"></div>
-      </div>
+        <div className="pointer-events-none absolute top-1/4 left-10 w-2 h-2 bg-cyan-400 rounded-full animate-ping delay-1000"></div>
+        <div className="pointer-events-none absolute top-1/3 right-20 w-3 h-3 bg-blue-500 rounded-full animate-ping delay-2000"></div>
+        <div className="pointer-events-none absolute bottom-1/4 left-1/4 w-1 h-1 bg-blue-400 rounded-full animate-ping delay-3000"></div>
+        <div className="pointer-events-none absolute top-1/2 right-1/3 w-2 h-2 bg-cyan-300 rounded-full animate-ping delay-1000"></div>
+      </section>
     </>
   )
 }

--- a/components/general/servicios.js
+++ b/components/general/servicios.js
@@ -28,7 +28,7 @@ export default function ServiciosComponent() {
         .delay-500 { animation-delay: 500ms; }
       `}</style>
 
-      <section className="py-16 lg:py-24 relative bg-gradient-to-br from-blue-800 to-blue-950 text-white">
+      <section className="relative overflow-hidden py-16 lg:py-24 bg-gradient-to-br from-blue-800 to-blue-950 text-white">
         {/* Background elements */}
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-20 right-10 w-64 h-64 bg-cyan-500/5 rounded-full blur-3xl animate-pulse"></div>


### PR DESCRIPTION
## Summary
- wrap hero, servicios, equipamiento, and contacto sections with overflow-hidden containers to constrain background accents
- limit floating accent layers to pointer-events-none and keep them within relative sections
- allow contact information text to break lines so long email addresses do not force horizontal scrolling

## Testing
- Verified via Playwright script that the page no longer introduces horizontal scrolling on a 375px wide viewport

------
https://chatgpt.com/codex/tasks/task_e_6900f3b139f4832f8be9d8b60e8b4f71